### PR TITLE
Add implicit cast from Message<T> to Hash to enable use in switch statements

### DIFF
--- a/src/defold/types/Message.hx
+++ b/src/defold/types/Message.hx
@@ -6,6 +6,6 @@ package defold.types;
     This abstract type wraps Hash and allows specifying message data
     as its type parameter. This is used to provide type-checked messaging.
 **/
-abstract Message<T>(Hash) {
+abstract Message<T>(Hash) to Hash {
     public inline function new(s:String) this = Defold.hash(s);
 }


### PR DESCRIPTION
Minor change which now enables the use of messages in switches statements. For example the following is now possible while it wasn't before:

```haxe
switch message_id
{
    case GoMessages.disable:
        foo();

    case GoMessages.enable:
        bar();
}
```