### PR TITLE
Add option to specify a root package for defold scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Haxe support library for the [Defold](https://www.defold.com/) game engine
 
-[![Build Status](https://travis-ci.org/hxdefold/hxdefold.svg?branch=master)](https://travis-ci.org/hxdefold/hxdefold) ![Defold API version: 1.2.151](https://img.shields.io/badge/api%20version-1.2.151-orange.svg)
+[![Build Status](https://travis-ci.org/hxdefold/hxdefold.svg?branch=master)](https://travis-ci.org/hxdefold/hxdefold) ![Defold API version: 1.2.164](https://img.shields.io/badge/api%20version-1.2.164-orange.svg)
 
 This library allows writing beautiful [Haxe](https://haxe.org/) code for KING's [Defold](https://www.defold.com/) game engine \o/
 

--- a/src/defold/Go.hx
+++ b/src/defold/Go.hx
@@ -366,7 +366,11 @@ abstract GoProperty(Dynamic)
     from Vector4 to Vector4
     from Quaternion to Quaternion
     from Bool to Bool
-    from ResourceReference to ResourceReference
+    from AtlasResourceReference to AtlasResourceReference
+    from FontResourceReference to FontResourceReference
+    from MaterialResourceReference to MaterialResourceReference
+    from TextureResourceReference to TextureResourceReference
+    from TileSourceResourceReference to TileSourceResourceReference
     {}
 
 /**

--- a/src/defold/Go.hx
+++ b/src/defold/Go.hx
@@ -172,6 +172,14 @@ extern class Go {
     static function get_world_scale_uniform(?id:HashOrStringOrUrl):Float;
 
     /**
+        Gets the world transform of a game object instance.
+
+        @param id optional id of the game object instance to get the world transform for, by default the instance of the calling script
+        @return instance world transform
+    **/
+    static function get_world_transform(?id:HashOrStringOrUrl):Matrix4;
+
+    /**
         Sets a named property of the specified game object or component.
 
         @param url url of the game object or component having the property
@@ -358,6 +366,7 @@ abstract GoProperty(Dynamic)
     from Vector4 to Vector4
     from Quaternion to Quaternion
     from Bool to Bool
+    from ResourceReference to ResourceReference
     {}
 
 /**

--- a/src/defold/Label.hx
+++ b/src/defold/Label.hx
@@ -9,6 +9,14 @@ import defold.types.*;
 **/
 @:native("_G.label")
 extern class Label {
+
+    /**
+        Gets the text from a label component
+
+        @return the label text
+    **/
+    static function get_text(url:HashOrStringOrUrl): String;
+
     /**
         Gets the text metrics from a label component
 

--- a/src/defold/Physics.hx
+++ b/src/defold/Physics.hx
@@ -71,6 +71,22 @@ extern class Physics {
     static function set_gravity(gravity:Vector3):Void;
 
     /**
+        Flips the collision shapes horizontally for a collision object
+
+        @param url the collision object that should flip its shapes
+        @param flip `true` if the collision object should flip its shapes, `false` if not
+    **/
+    static function set_hflip(url:HashOrStringOrUrl, flip:Bool):Void;
+
+    /**
+        Flips the collision shapes vertically for a collision object
+
+        @param url the collision object that should flip its shapes
+        @param flip `true` if the collision object should flip its shapes, `false` if not
+    **/
+    static function set_vflip(url:HashOrStringOrUrl, flip:Bool):Void;
+
+    /**
         Create a physics joint between two collision object components.
 
         Note: Currently only supported in 2D physics.

--- a/src/defold/Resource.hx
+++ b/src/defold/Resource.hx
@@ -1,13 +1,35 @@
 package defold;
 
+import defold.types.Hash;
 import defold.types.Buffer;
 import defold.types.HashOrString;
+import defold.types.ResourceReference;
 
 /**
     Functions and constants to access resources.
 **/
 @:native("_G.resource")
 extern class Resource {
+    /**
+        Constructor-like function with two purposes:
+
+        - Load the specified resource as part of loading the script
+        - Return a hash to the run-time version of the resource
+
+        **Note:** This function can only be called within `@property()`.
+    **/
+    static function atlas(path:Hash):ResourceReference;
+
+    /**
+        Constructor-like function with two purposes:
+
+        - Load the specified resource as part of loading the script
+        - Return a hash to the run-time version of the resource
+
+        **Note:** This function can only be called within `@property()`.
+    **/
+    static function font(path:Hash):ResourceReference;
+
     /**
         Return a reference to the Manifest that is currently loaded.
 
@@ -22,6 +44,16 @@ extern class Resource {
         @return the buffer stored on disc
     **/
     static function load(path:String):Buffer;
+
+    /**
+        Constructor-like function with two purposes:
+
+        - Load the specified resource as part of loading the script
+        - Return a hash to the run-time version of the resource
+
+        **Note:** This function can only be called within `@property()`.
+    **/
+    static function material():ResourceReference;
 
     /**
         Sets the resource data for a specific resource
@@ -74,6 +106,26 @@ extern class Resource {
          * `status` Whether or not the resource was successfully stored.
     **/
     static function store_resource<T>(manifest_reference:ResourceManifestReference, data:String, hexdigest:String, callback:T->String->Bool->Void):Void;
+
+    /**
+        Constructor-like function with two purposes:
+
+        - Load the specified resource as part of loading the script
+        - Return a hash to the run-time version of the resource
+
+        **Note:** This function can only be called within `@property()`.
+    **/
+    static function texture(path:Hash):ResourceReference;
+
+    /**
+        Constructor-like function with two purposes:
+
+        - Load the specified resource as part of loading the script
+        - Return a hash to the run-time version of the resource
+
+        **Note:** This function can only be called within `@property()`.
+    **/
+    static function tile_source(path:Hash):ResourceReference;
 }
 
 /**

--- a/src/defold/Resource.hx
+++ b/src/defold/Resource.hx
@@ -3,7 +3,11 @@ package defold;
 import defold.types.Hash;
 import defold.types.Buffer;
 import defold.types.HashOrString;
-import defold.types.ResourceReference;
+import defold.types.AtlasResourceReference;
+import defold.types.FontResourceReference;
+import defold.types.MaterialResourceReference;
+import defold.types.TextureResourceReference;
+import defold.types.TileSourceResourceReference;
 
 /**
     Functions and constants to access resources.
@@ -18,7 +22,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function atlas(path:String):ResourceReference;
+    static function atlas(path:String):AtlasResourceReference;
 
     /**
         Constructor-like function with two purposes:
@@ -28,7 +32,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function font(path:String):ResourceReference;
+    static function font(path:String):FontResourceReference;
 
     /**
         Return a reference to the Manifest that is currently loaded.
@@ -53,7 +57,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function material():ResourceReference;
+    static function material():MaterialResourceReference;
 
     /**
         Sets the resource data for a specific resource
@@ -115,7 +119,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function texture(path:String):ResourceReference;
+    static function texture(path:String):TextureResourceReference;
 
     /**
         Constructor-like function with two purposes:
@@ -125,7 +129,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function tile_source(path:String):ResourceReference;
+    static function tile_source(path:String):TileSourceResourceReference;
 }
 
 /**

--- a/src/defold/Resource.hx
+++ b/src/defold/Resource.hx
@@ -18,7 +18,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function atlas(path:Hash):ResourceReference;
+    static function atlas(path:String):ResourceReference;
 
     /**
         Constructor-like function with two purposes:
@@ -28,7 +28,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function font(path:Hash):ResourceReference;
+    static function font(path:String):ResourceReference;
 
     /**
         Return a reference to the Manifest that is currently loaded.
@@ -115,7 +115,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function texture(path:Hash):ResourceReference;
+    static function texture(path:String):ResourceReference;
 
     /**
         Constructor-like function with two purposes:
@@ -125,7 +125,7 @@ extern class Resource {
 
         **Note:** This function can only be called within `@property()`.
     **/
-    static function tile_source(path:Hash):ResourceReference;
+    static function tile_source(path:String):ResourceReference;
 }
 
 /**

--- a/src/defold/Sound.hx
+++ b/src/defold/Sound.hx
@@ -100,7 +100,7 @@ extern class Sound {
         @param url the sound that should play
         @param play_properties optional table with properties
     **/
-    static function play(url:HashOrStringOrUrl, ?play_properties:SoundMessagePlaySound):Void;
+    static function play<T>(url:HashOrStringOrUrl, ?play_properties:SoundMessagePlaySound, ?complete_function:(T,Hash,SoundMessageSoundDone,Url)->Void):Void;
 
     /**
         Set gain on all active playing voices of a sound.
@@ -123,6 +123,16 @@ extern class Sound {
         @param gain gain in linear scale
     **/
     static function set_group_gain(group:HashOrString, gain:Float):Bool;
+
+    /**
+        Set panning on all active playing voices of a sound.
+
+        The valid range is from `-1.0` to `1.0`, representing `-45` degrees left, to `+45` degrees right.
+
+        @param url the sound to set the panning value to
+        @param pan sound panning between `-1.0` and `1.0`
+    **/
+    static function set_pan(url:HashOrStringOrUrl, pan:Float):Void;
 
     /**
         Stop a playing a sound(s).
@@ -159,6 +169,11 @@ class SoundMessages {
         Post this message to a sound-component to make it stop playing all active voices
     **/
     static var stop_sound(default, never) = new Message<Void>("stop_sound");
+
+    /**
+        Callback message indicating that a sound has finished playing.
+    **/
+    static var sound_done(default, never) = new Message<Void>("sound_done");
 }
 
 /**
@@ -186,6 +201,16 @@ typedef SoundMessageSetGain = {
         Sound gain between 0 and 1, default is 1.
     **/
     @:optional var gain:Float;
+}
+
+/**
+    Data for the `SoundMessages.sound_done` message.
+**/
+typedef SoundMessageSoundDone = {
+    /**
+        The sequential play identifier that was given by the sound.play function.
+    **/
+    @:optional var play_id: Int;
 }
 
 /**

--- a/src/defold/Sound.hx
+++ b/src/defold/Sound.hx
@@ -100,7 +100,7 @@ extern class Sound {
         @param url the sound that should play
         @param play_properties optional table with properties
     **/
-    static function play<T>(url:HashOrStringOrUrl, ?play_properties:SoundMessagePlaySound, ?complete_function:(T,Hash,SoundMessageSoundDone,Url)->Void):Void;
+    static function play<T>(url:HashOrStringOrUrl, ?play_properties:SoundMessagePlaySound, ?complete_function:T->Hash->SoundMessageSoundDone->Url->Void):Void;
 
     /**
         Set gain on all active playing voices of a sound.

--- a/src/defold/Sys.hx
+++ b/src/defold/Sys.hx
@@ -71,6 +71,13 @@ extern class Sys {
     static function get_application_info(_:String):SysApplicationInfo; // TODO: wtf is this string arg?
 
     /**
+        The path from which the application is run.
+
+        @return path to application executable
+    **/
+    static function get_application_path(): String;
+
+    /**
         Get config value from the game.project configuration file.
 
         In addition to the project file, configuration values can also be passed
@@ -150,7 +157,7 @@ extern class Sys {
         @param filename resource to load, full path
         @return loaded data, which is empty if the file could not be found
     **/
-    static function load_resource(filename:String):Null<String>;
+    static function load_resource(filename:String):SysResource;
 
     /**
         Open url in default application.
@@ -418,7 +425,7 @@ typedef SysIfaddr = {
     /**
         Hardware address, colon separated string (null if not available).
     **/
-    var mac:Null<String>;
+    var mac:String;
     var up:Bool;
     var running:Bool;
 }
@@ -480,17 +487,22 @@ typedef SysSysInfo = {
     var device_ident:String;
 
     /**
-        "advertisingIdentifier" on iOS, advertising ID provided by Google Play on Android.
-    **/
-    var ad_ident:String;
-
-    /**
-         true if ad tracking is enabled, false otherwise.
-    **/
-    var ad_tracking_enabled:Bool;
-
-    /**
         The HTTP user agent, i.e. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8"
     **/
     var user_agent:String;
+}
+
+/**
+    The returned value of `Sys.load_resource()`.
+**/
+@:multiReturn extern class SysResource {
+    /**
+        Loaded data, or `null` if the resource could not be loaded.
+    **/
+    var data: String;
+
+    /**
+        The error message, or `null` if no error occurred.
+    **/
+    var error: String;
 }

--- a/src/defold/Tilemap.hx
+++ b/src/defold/Tilemap.hx
@@ -92,6 +92,15 @@ extern class Tilemap {
         @param v_flip if the tile should be vertically flipped
     **/
     static function set_tile(url:HashOrStringOrUrl, name:HashOrString, x:Int, y:Int, new_tile:Int, ?h_flip:Bool, ?v_flip:Bool):Void;
+
+    /**
+        Sets the visibility of the tilemap layer.
+
+        @param url the tile map
+        @param layer name of the layer
+        @param visible should the layer be visible
+    **/
+    static function set_visible(url:HashOrStringOrUrl, layer:HashOrString, visible: Bool):Void;
 }
 
 /**

--- a/src/defold/Vmath.hx
+++ b/src/defold/Vmath.hx
@@ -1,5 +1,7 @@
 package defold;
 
+import haxe.extern.EitherType;
+
 import defold.types.*;
 
 /**
@@ -263,6 +265,14 @@ extern class Vmath {
         @return matrix from rotation around z-axis
     **/
     static function matrix4_rotation_z(angle:Float):Matrix4;
+
+    /**
+        The resulting matrix describes a translation of a point in euclidean space.
+
+        @param position position vector to create matrix from
+        @return matrix from the supplied position vector
+    **/
+    static function matrix4_translation(position:EitherType<Vector3,Vector4>): Matrix4;
 
     /**
         Performs an element wise multiplication between two vectors of the same type

--- a/src/defold/support/Run.hx
+++ b/src/defold/support/Run.hx
@@ -37,6 +37,10 @@ class Run {
 		"#-D hxdefold-projectroot=.",
 		"# override to specify another output directory for generated script files (relative to the project root)",
 		"#-D hxdefold-scriptdir=scripts",
+		"# specify a package in your source which contains all of your scripts",
+		"# only scripts under that package will be included in the output",
+		"# they will then appear starting at the top of the scripts dir without extra folders for intermediate packages",
+		"#-D hxdefold-rootpackage=mygame.scripts",
 	].join("\n");
 
 	static var sample =

--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -219,7 +219,6 @@ private class Glue {
             var scriptDir = Path.join([outDir].concat(scriptDirParts));
             var fileName = cl.name + "." + ext;
 
-
             scripts.push({
                 properties: props,
                 callbacks: callbacks,

--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -193,35 +193,30 @@ private class Glue {
                 $b{exportExprs};
             });
 
-            var scriptDirParts = cl.pack;
+            var scriptPackage = cl.pack;
 
-            // strip the root package from the beginning of the path
+            // Strip the root package from the beginning of the path.
             var rootPackage = Context.definedValue("hxdefold-rootpackage");
             if (rootPackage != null)
             {
                 var rootPackageParts = rootPackage.split('.');
-                var includeScript: Bool = true;
 
                 for (i in 0...rootPackageParts.length)
                 {
-                    if (rootPackageParts[i] == scriptDirParts[0])
+                    if (rootPackageParts[i] == scriptPackage[0])
                     {
-                        scriptDirParts = scriptDirParts.slice(1);
+                        scriptPackage = scriptPackage.slice(1);
                     }
                     else
                     {
-                        // script is not under the root package, exclude it
-                        includeScript = false;
-                        break;
+                        // Script is not under the root package, exclude it.
+                        continue;
                     }
                 }
-
-                if (!includeScript)
-                    continue;
             }
 
             // finally, save the generated script file, using the name of the class
-            var scriptDir = Path.join([outDir].concat(cl.pack));
+            var scriptDir = Path.join([outDir].concat(scriptPackage));
             var fileName = cl.name + "." + ext;
 
             scripts.push({

--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -188,30 +188,35 @@ private class Glue {
                 $b{exportExprs};
             });
 
-            var scriptPackage = cl.pack;
+            var scriptDirParts = cl.pack;
 
-            // Strip the root package from the beginning of the path.
+            // strip the root package from the beginning of the path
             var rootPackage = Context.definedValue("hxdefold-rootpackage");
             if (rootPackage != null)
             {
                 var rootPackageParts = rootPackage.split('.');
+                var includeScript: Bool = true;
 
                 for (i in 0...rootPackageParts.length)
                 {
-                    if (rootPackageParts[i] == scriptPackage[0])
+                    if (rootPackageParts[i] == scriptDirParts[0])
                     {
-                        scriptPackage = scriptPackage.slice(1);
+                        scriptDirParts = scriptDirParts.slice(1);
                     }
                     else
                     {
-                        // Script is not under the root package, exclude it.
-                        continue;
+                        // script is not under the root package, exclude it
+                        includeScript = false;
+                        break;
                     }
                 }
+                
+                if (!includeScript)
+                    continue;
             }
 
             // finally, save the generated script file, using the name of the class
-            var scriptDir = Path.join([outDir].concat(scriptPackage));
+            var scriptDir = Path.join([outDir].concat(scriptDirParts));
             var fileName = cl.name + "." + ext;
 
 

--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -24,6 +24,11 @@ private enum PropertyType {
     PVector3;
     PVector4;
     PQuaternion;
+    PAtlasResourceReference;
+    PFontResourceReference;
+    PMaterialResourceReference;
+    PTextureResourceReference;
+    PTileSourceResourceReference;
 }
 
 private typedef ScriptExport = {
@@ -188,6 +193,36 @@ private class Glue {
                 $b{exportExprs};
             });
 
+<<<<<<< Updated upstream
+=======
+            var scriptDirParts = cl.pack;
+
+            // strip the root package from the beginning of the path
+            var rootPackage = Context.definedValue("hxdefold-rootpackage");
+            if (rootPackage != null)
+            {
+                var rootPackageParts = rootPackage.split('.');
+                var includeScript: Bool = true;
+
+                for (i in 0...rootPackageParts.length)
+                {
+                    if (rootPackageParts[i] == scriptDirParts[0])
+                    {
+                        scriptDirParts = scriptDirParts.slice(1);
+                    }
+                    else
+                    {
+                        // script is not under the root package, exclude it
+                        includeScript = false;
+                        break;
+                    }
+                }
+
+                if (!includeScript)
+                    continue;
+            }
+
+>>>>>>> Stashed changes
             // finally, save the generated script file, using the name of the class
             var scriptDir = Path.join([outDir].concat(cl.pack));
             var fileName = cl.name + "." + ext;
@@ -297,6 +332,11 @@ private class Glue {
             case TAbstract(_.get() => {pack: [], name: "Int"}, _): PInt;
             case TAbstract(_.get() => {pack: [], name: "Float"}, _): PFloat;
             case TAbstract(_.get() => {pack: [], name: "Bool"}, _): PBool;
+            case TAbstract(_.get() => {pack: ["defold", "types"], name: "AtlasResourceReference"}, _): PAtlasResourceReference;
+            case TAbstract(_.get() => {pack: ["defold", "types"], name: "FontResourceReference"}, _): PFontResourceReference;
+            case TAbstract(_.get() => {pack: ["defold", "types"], name: "MaterialResourceReference"}, _): PMaterialResourceReference;
+            case TAbstract(_.get() => {pack: ["defold", "types"], name: "TextureResourceReference"}, _): PTextureResourceReference;
+            case TAbstract(_.get() => {pack: ["defold", "types"], name: "TileSourceResourceReference"}, _): PTileSourceResourceReference;
             default: throw new Error('Unsupported type for script property: ${type.toString()}', pos);
         }
     }
@@ -311,6 +351,11 @@ private class Glue {
             case PInt: '0';
             case PFloat: '0.0';
             case PQuaternion: 'vmath.quat()';
+            case PAtlasResourceReference
+                | PFontResourceReference
+                | PMaterialResourceReference
+                | PTextureResourceReference
+                | PTileSourceResourceReference: throw new Error('Property of type ${Std.string(type).substr(1)} cannot have an empty value.', Context.currentPos());
         }
     }
 
@@ -332,6 +377,17 @@ private class Glue {
                 'vmath.vector4($x, $y, $z, $w)';
             case [PQuaternion, [{expr: EConst(CFloat(x) | CInt(x))}, {expr: EConst(CFloat(y) | CInt(y))}, {expr: EConst(CFloat(z) | CInt(z))}, {expr: EConst(CFloat(w) | CInt(w))}]]:
                 'vmath.quat($x, $y, $z, $w)';
+            case [PAtlasResourceReference, [{expr: EConst(CString(s))}]]:
+                'resource.atlas(${haxe.Json.stringify(s)})';
+            case [PFontResourceReference, [{expr: EConst(CString(s))}]]:
+                'resource.font(${haxe.Json.stringify(s)})';
+            case [PMaterialResourceReference, [{expr: EConst(CString(s))}]]:
+                'resource.material(${haxe.Json.stringify(s)})';
+            case [PTextureResourceReference, [{expr: EConst(CString(s))}]]:
+                'resource.texture(${haxe.Json.stringify(s)})';
+            case [PTileSourceResourceReference, [{expr: EConst(CString(s))}]]:
+                'resource.tile_source(${haxe.Json.stringify(s)})';
+
             default:
                 throw new Error('Invalid @property value for type ${type.getName().substr(1)}', pos);
         }

--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -188,9 +188,32 @@ private class Glue {
                 $b{exportExprs};
             });
 
+            var scriptPackage = cl.pack;
+
+            // Strip the root package from the beginning of the path.
+            var rootPackage = Context.definedValue("hxdefold-rootpackage");
+            if (rootPackage != null)
+            {
+                var rootPackageParts = rootPackage.split('.');
+
+                for (i in 0...rootPackageParts.length)
+                {
+                    if (rootPackageParts[i] == scriptPackage[0])
+                    {
+                        scriptPackage = scriptPackage.slice(1);
+                    }
+                    else
+                    {
+                        // Script is not under the root package, exclude it.
+                        continue;
+                    }
+                }
+            }
+
             // finally, save the generated script file, using the name of the class
-            var scriptDir = Path.join([outDir].concat(cl.pack));
+            var scriptDir = Path.join([outDir].concat(scriptPackage));
             var fileName = cl.name + "." + ext;
+
 
             scripts.push({
                 properties: props,

--- a/src/defold/types/AtlasResourceReference.hx
+++ b/src/defold/types/AtlasResourceReference.hx
@@ -1,0 +1,8 @@
+package defold.types;
+
+/**
+    A reference hash to a run-time version of an atlas resource.
+**/
+abstract AtlasResourceReference(Hash) {
+
+}

--- a/src/defold/types/FontResourceReference.hx
+++ b/src/defold/types/FontResourceReference.hx
@@ -1,0 +1,8 @@
+package defold.types;
+
+/**
+    A reference hash to a run-time version of a font resource.
+**/
+abstract FontResourceReference(Hash) {
+
+}

--- a/src/defold/types/MaterialResourceReference.hx
+++ b/src/defold/types/MaterialResourceReference.hx
@@ -1,0 +1,8 @@
+package defold.types;
+
+/**
+    A reference hash to a run-time version of a material resource.
+**/
+abstract MaterialResourceReference(Hash) {
+
+}

--- a/src/defold/types/ResourceReference.hx
+++ b/src/defold/types/ResourceReference.hx
@@ -1,8 +1,0 @@
-package defold.types;
-
-/**
-    A reference hash to a run-time version of a resource.
-**/
-abstract ResourceReference(Hash) { 
-    
-}

--- a/src/defold/types/ResourceReference.hx
+++ b/src/defold/types/ResourceReference.hx
@@ -3,4 +3,6 @@ package defold.types;
 /**
     A reference hash to a run-time version of a resource.
 **/
-typedef ResourceReference = Hash;
+abstract ResourceReference(Hash) { 
+    
+}

--- a/src/defold/types/ResourceReference.hx
+++ b/src/defold/types/ResourceReference.hx
@@ -1,0 +1,6 @@
+package defold.types;
+
+/**
+    A reference hash to a run-time version of a resource.
+**/
+typedef ResourceReference = Hash;

--- a/src/defold/types/TextureResourceReference.hx
+++ b/src/defold/types/TextureResourceReference.hx
@@ -1,0 +1,8 @@
+package defold.types;
+
+/**
+    A reference hash to a run-time version of a material resource.
+**/
+abstract TextureResourceReference(Hash) {
+
+}

--- a/src/defold/types/TileSourceResourceReference.hx
+++ b/src/defold/types/TileSourceResourceReference.hx
@@ -1,0 +1,8 @@
+package defold.types;
+
+/**
+    A reference hash to a run-time version of a font resource.
+**/
+abstract TileSourceResourceReference(Hash) {
+
+}

--- a/src/defold/types/Vector3.hx
+++ b/src/defold/types/Vector3.hx
@@ -25,6 +25,11 @@ extern abstract Vector3(Vector3Data) {
         return untyped __lua__("({0}) * ({1})", a, b);
     }
 
+    @:op(a / b) @:commutative
+    private static inline function divScalar(a:Vector3, b:Float):Vector3 {
+        return untyped __lua__("({0}) / ({1})", a, b);
+    }
+
     @:op(a * b)
     private static inline function mul(a:Vector3, b:Vector3):Vector3 {
         return untyped __lua__("({0}) * ({1})", a, b);

--- a/src/defold/types/Vector3.hx
+++ b/src/defold/types/Vector3.hx
@@ -25,7 +25,7 @@ extern abstract Vector3(Vector3Data) {
         return untyped __lua__("({0}) * ({1})", a, b);
     }
 
-    @:op(a / b) @:commutative
+    @:op(a / b)
     private static inline function divScalar(a:Vector3, b:Float):Vector3 {
         return untyped __lua__("({0}) / ({1})", a, b);
     }

--- a/src/defold/types/Vector4.hx
+++ b/src/defold/types/Vector4.hx
@@ -25,7 +25,7 @@ extern abstract Vector4(Vector4Data) {
         return untyped __lua__("({0}) * ({1})", a, b);
     }
 
-    @:op(a / b) @:commutative
+    @:op(a / b)
     private static inline function divScalar(a:Vector4, b:Float):Vector4 {
         return untyped __lua__("({0}) / ({1})", a, b);
     }

--- a/src/defold/types/Vector4.hx
+++ b/src/defold/types/Vector4.hx
@@ -25,6 +25,11 @@ extern abstract Vector4(Vector4Data) {
         return untyped __lua__("({0}) * ({1})", a, b);
     }
 
+    @:op(a / b) @:commutative
+    private static inline function divScalar(a:Vector4, b:Float):Vector4 {
+        return untyped __lua__("({0}) / ({1})", a, b);
+    }
+
     @:op(a * b)
     private static inline function mul(a:Vector4, b:Vector4):Vector4 {
         return untyped __lua__("({0}) * ({1})", a, b);


### PR DESCRIPTION
This is something I added for personal use and I'm not sure how it will fit in with the library, but I'm making a PR anyway just in case anybody else wants it also.

Basically I added an optional `hxdefold-rootpackage` build flag, which allows the user to specify a package name under which all scripts will be contained. The benefit from doing so is that the output scripts directory will then not contain the extra folders from intermediate packages leading up to the scripts.

#### Current implementation

Scripts located at:

```
src/game/scripts/PlayerMovement.hx
src/game/scripts/environment/Tree.hx
```

Will generate scripts at:

```
{scriptdir}/game/scripts/PlayerMovement.script
{scriptdir}/game/scripts/environment/Tree.script
```


#### New implementation

Scripts located at:

```
src/game/scripts/PlayerMovement.hx
src/game/scripts/environment/Tree.hx
```

Setting the flag to:

```
-D hxdefold-rootpackage=game.scripts
```


Will generate scripts at:

```
{scriptdir}/PlayerMovement.script
{scriptdir}/environment/Tree.script
```

Thus avoiding the two extra intermediate folders and making the scripts folder a bit easier to navigate in the Defold editor.

