### PR TITLE
Add support for subclassing script types, including generics.

### DIFF
--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -218,8 +218,7 @@ private class Glue {
     }
 
 
-    function generateCallbacksRecursive(cl:ClassType, exportExprs:Array<Expr>, exportPrefix:String, baseMethods:Map<String,Bool>, callbackNames:Array<String> = null):Array<Callback>
-    {
+    function generateCallbacksRecursive(cl:ClassType, exportExprs:Array<Expr>, exportPrefix:String, baseMethods:Map<String,Bool>, callbackNames:Array<String> = null):Array<Callback> {
         if (isBaseScriptType(cl)) {
             // Reached the base script type, stop here.
             return [];

--- a/src/defold/support/ScriptMacro.hx
+++ b/src/defold/support/ScriptMacro.hx
@@ -444,13 +444,13 @@ private class Glue {
     **/
     static function getScriptPropertiesType(cl:ClassType):Type {
         return switch (cl) {
-            // Check if the base class is a type of script.
+            // Check if there is a super class with a type parameter.
             case {superClass: {params: [tData]}}: tData;
 
-            // If not, and it has a baseclass, check it recursively.
+            // If there is a super class, but without a type parameter, check it recursively.
             case _ if (cl.superClass != null): getScriptPropertiesType(cl.superClass.t.get());
 
-            // Otherwise it's definitely not s cript.
+            // Otherwise it's definitely not a script.
             default: throw new Error('getScriptPropertiesType() called for a type that is not a script.', Context.currentPos());
         }
     }


### PR DESCRIPTION
Hey, with this PR I have implemented the following:

1. It is now possible to extend script types.
    - All classes that have a `Script` type somewhere down the inheritance line, will have a script file generated.
    - Callbacks for base methods will be correctly generated in the case where a script class does not define one, but one of the parent types does.
2. It is now possible to define generic scripts.
    - Generic script types only need to have the `<T:{}>` constraint.
    - Classes which extend a `Script` type but are generic, will have no script file generated.

Here are some examples.

```haxe
// BaseScript.script will be generated
class BaseScript extends Script<BaseProperties> {
    override function update(self:BaseProperties, dt:Float) { }
}
```

```haxe
// ExtScript.script will be generated
class ExtScript extends BaseScript {

    // Here, "self" has the properties of the base script.
    override function init(self:BaseProperties) { }

    // The callback for update() is omitted, so it will be generated to point to BaseScript.update()
}
```

Another script can extend `ExtScript` and so on...

Also an example with a generic script:

```haxe
// GenericScript.script will NOT be generated
class GenericScript<T:{}> extends Script<T> {

}
```

```haxe
// ImplScript.script will be generated
class ImplScript extends GenericScript<ImplProperties> {

    // Here, "self" has the properties used as T
    override function init(self:ImplProperties) { }
}
```

The type checking is recursive, so you can have a script `A`, which extends script `B`, which extends generic script `C`, which extends script `D`, which extends `Script` etc.

From what I have tested so far it seems to work as intended, waiting for feedback 😄 

This also closes #18 

