### PR TITLE
Update Physics.hx

### DIFF
--- a/src/defold/Physics.hx
+++ b/src/defold/Physics.hx
@@ -262,6 +262,20 @@ extern final class Physics
      */
     @:native('update_mass')
     static function updateMass(collisionobject:HashOrStringOrUrl, mass:Float):Void;
+
+    /**
+     * Sets a physics world event listener. If a function is set, physics messages will no longer be sent.     
+     */
+    static inline function setListener(callback:(event:Hash, data:Dynamic)->Void):Void
+    {
+        setListener_((self, event, data) ->
+        {
+            untyped __lua__('_G._hxdefold_self_ = {0}', self);
+            callback(event, data);
+            untyped __lua__('_G._hxdefold_self_ = nil');
+        });
+    }
+    @:native('set_listener') private static function setListener_(callback:(Any, Hash, Dynamic)->Void):Void;
 }
 
 /**


### PR DESCRIPTION
Setup the Physics listener.
This case I really try to avoid the Dynamic for the data table that returns, but each event:Hash message the data table change.

But for now this works. The thing is for each event like 

```haxe
function onPhysicsContact(event:Hash, data:Dynamic):Void 
{
	if (event == hash("trigger_event")) 
        {
          trace(data.enter); // true or false
          trace(data.a.id); // [/go2]
          trace(data.a.group); // [default],
          trace(data.b.id); // this is the other player trigger sensor, this is sensor.
        }
}
```

well the data that return is here.
https://defold.com/ref/stable/physics/#physics.set_listener:callback